### PR TITLE
Add MySQL environment configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ php -S localhost:8000 -t public
 
 Při prvním spuštění se automaticky vytvoří soubor `var/database.sqlite` a naplní se ukázkovými daty. Přihlášení do administrace je dostupné na `/admin` s údaji `admin` / `admin123` (doporučujeme změnit heslo).
 
+### MySQL konfigurace
+
+Nastavte proměnné prostředí `DB_HOST`, `DB_DATABASE`, `DB_USERNAME` a `DB_PASSWORD` (volitelně `DB_PORT` a `DB_CHARSET`), aby se aplikace připojila k MySQL. Pokud nejsou tyto proměnné definované, použije se lokální SQLite databáze ve složce `var/`.
+
 ## Struktura projektu
 
 - `public/` – veřejné vstupní body `index.php` a `admin/index.php` + statická aktiva

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -15,10 +15,34 @@ class Connection
             return self::$pdo;
         }
 
-        $databaseUrl = getenv('DATABASE_URL');
-        if ($databaseUrl) {
+        $mysqlHost = getenv('DB_HOST');
+        $mysqlDatabase = getenv('DB_DATABASE');
+
+        if ($mysqlHost && $mysqlDatabase) {
+            $mysqlPort = getenv('DB_PORT');
+            $mysqlCharset = getenv('DB_CHARSET') ?: 'utf8mb4';
+
+            $dsn = sprintf('mysql:host=%s;dbname=%s;charset=%s', $mysqlHost, $mysqlDatabase, $mysqlCharset);
+            if ($mysqlPort) {
+                $dsn .= ';port=' . $mysqlPort;
+            }
+
+            $options = [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ];
+
+            if (defined('PDO::MYSQL_ATTR_INIT_COMMAND')) {
+                $options[PDO::MYSQL_ATTR_INIT_COMMAND] = sprintf('SET NAMES %s', $mysqlCharset);
+            }
+
+            $username = getenv('DB_USERNAME') ?: null;
+            $password = getenv('DB_PASSWORD') ?: null;
+        } elseif ($databaseUrl = getenv('DATABASE_URL')) {
             $dsn = $databaseUrl;
             $options = [];
+            $username = null;
+            $password = null;
         } else {
             $dbPath = __DIR__ . '/../../var/database.sqlite';
             if (!is_dir(dirname($dbPath))) {
@@ -26,10 +50,12 @@ class Connection
             }
             $dsn = 'sqlite:' . $dbPath;
             $options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION];
+            $username = null;
+            $password = null;
         }
 
         try {
-            self::$pdo = new PDO($dsn, null, null, $options);
+            self::$pdo = new PDO($dsn, $username, $password, $options);
             self::$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (PDOException $e) {
             throw new PDOException('Nepodařilo se připojit k databázi: ' . $e->getMessage(), (int) $e->getCode(), $e);


### PR DESCRIPTION
## Summary
- allow the connection factory to prioritise MySQL configuration from DB_* environment variables with sensible defaults
- retain the DATABASE_URL and SQLite fallbacks while still running migrations on the established connection
- document the environment variables required to enable the MySQL connection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf4c04b7c83318a3b929dffa7ac2e